### PR TITLE
tests: fix incompatibility with pytest>=2.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_install:
   - "sudo apt-get update"
   - "sudo apt-get install python-dev"
   - "travis_retry pip install --upgrade pip"
-  - "travis_retry pip install mock"
+  - "travis_retry pip install check-manifest mock"
   - "python requirements.py --extras=$REXTRAS --level=min > .travis-lowest-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=pypi > .travis-release-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=dev > .travis-devel-requirements.txt"
@@ -61,6 +61,7 @@ before_script:
   - "inveniomanage database create --quiet || echo ':('"
 
 script:
+  - "check-manifest --ignore .travis-\\*-requirements.txt"
   - "sphinx-build -qnN docs docs/_build/html"
   - "python setup.py test"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_install:
   - "sudo apt-get update"
   - "sudo apt-get install python-dev"
   - "travis_retry pip install --upgrade pip"
-  - "travis_retry pip install check-manifest mock"
+  - "travis_retry pip install check-manifest mock coveralls"
   - "python requirements.py --extras=$REXTRAS --level=min > .travis-lowest-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=pypi > .travis-release-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=dev > .travis-devel-requirements.txt"

--- a/invenio_redirector/api.py
+++ b/invenio_redirector/api.py
@@ -19,7 +19,7 @@
 
 """Redirecting engine."""
 
-from invenio.ext.sqlalchemy import db
+from invenio_ext.sqlalchemy import db
 
 from .models import Goto
 
@@ -97,7 +97,7 @@ def update_redirection(label, plugin, parameters=None):
     goto.parameters = parameters
     try:
         db.session.merge(goto)
-    except:
+    except Exception:
         db.session.rollback()
         # FIXME add re-raise exception
     finally:

--- a/invenio_redirector/manage.py
+++ b/invenio_redirector/manage.py
@@ -21,7 +21,7 @@
 
 from __future__ import print_function
 
-from invenio.ext.script import Manager
+from invenio_ext.script import Manager
 
 manager = Manager(usage=__doc__)
 

--- a/invenio_redirector/manage.py
+++ b/invenio_redirector/manage.py
@@ -31,7 +31,7 @@ manager = Manager(usage=__doc__)
                 action="store_true")
 def create(label, plugin, parameters, update_redirection=False):
     """Register redirection page."""
-    from invenio.utils.json import json, json_unicode_to_utf8
+    from invenio_utils.json import json, json_unicode_to_utf8
     from .api import register_redirection
 
     parameters = json_unicode_to_utf8(json.loads(parameters))
@@ -54,7 +54,7 @@ def read(label):
 @manager.option("-p", "--parameters", dest="parameters")
 def update(label, plugin, parameters=None):
     """Update an existing redirection."""
-    from invenio.utils.json import json, json_unicode_to_utf8
+    from invenio_utils.json import json, json_unicode_to_utf8
     from .api import update_redirection
     parameters = parameters or '{}'
     parameters = json_unicode_to_utf8(json.loads(parameters))

--- a/invenio_redirector/models.py
+++ b/invenio_redirector/models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013, 2014 CERN.
+# Copyright (C) 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -22,10 +22,10 @@
 # External imports
 import datetime
 
-from sqlalchemy.orm import validates
-
 # General imports.
-from invenio.ext.sqlalchemy import db
+from invenio_ext.sqlalchemy import db
+
+from sqlalchemy.orm import validates
 
 from .registry import redirect_methods
 
@@ -67,11 +67,11 @@ class Goto(db.Model):
         self._parameters = value or {}
 
     def to_dict(self):
-        """ Return a dict representation of Goto."""
+        """Return a dict representation of Goto."""
         return {'label': self.label,
                 'plugin': self.plugin,
                 'parameters': self.parameters,
                 'creation_date': self.creation_date,
                 'modification_date': self.modification_date}
 
-__all__ = ['Goto']
+__all__ = ('Goto',)

--- a/invenio_redirector/registry.py
+++ b/invenio_redirector/registry.py
@@ -22,7 +22,8 @@
 from flask_registry import RegistryProxy
 
 from invenio.ext.registry import ModuleAutoDiscoverySubRegistry
-from invenio.utils.datastructures import LazyDict
+
+from invenio_utils.datastructures import LazyDict
 
 redirector_proxy = RegistryProxy('redirect_methods',
                                  ModuleAutoDiscoverySubRegistry,

--- a/invenio_redirector/registry.py
+++ b/invenio_redirector/registry.py
@@ -21,7 +21,7 @@
 
 from flask_registry import RegistryProxy
 
-from invenio.ext.registry import ModuleAutoDiscoverySubRegistry
+from invenio_ext.registry import ModuleAutoDiscoverySubRegistry
 
 from invenio_utils.datastructures import LazyDict
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,6 +23,6 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 [pytest]
-addopts = --clearcache --pep8 --ignore=docs --cov=invenio_redirector --cov-report=term-missing
+addopts = --pep8 --ignore=docs --cov=invenio_redirector --cov-report=term-missing
 pep8ignore =
     tests/* ALL

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -23,3 +23,4 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 -e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
+-e git+git://github.com/inveniosoftware/invenio-utils.git#egg=invenio-utils

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -23,4 +23,5 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 -e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
+-e git+git://github.com/inveniosoftware/invenio-ext.git#egg=invenio-ext
 -e git+git://github.com/inveniosoftware/invenio-utils.git#egg=invenio-utils

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
     'invenio-base>=0.2.1',
+    'invenio-utils>=0.1.0',
 ]
 
 test_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -40,10 +40,10 @@ requirements = [
 ]
 
 test_requirements = [
-    'pytest>=2.7.0',
-    'pytest-cov>=1.8.0',
+    'pytest>=2.8.0',
+    'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
-    'coverage>=3.7.1',
+    'coverage>=4.0.0',
 ]
 
 
@@ -75,9 +75,6 @@ class PyTest(TestCommand):
         """Run tests."""
         # import here, cause outside the eggs aren't loaded
         import pytest
-        import _pytest.config
-        pm = _pytest.config.get_plugin_manager()
-        pm.consider_setuptools_entrypoints()
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
     'invenio-base>=0.2.1',
+    'invenio-ext>=0.1.0',
     'invenio-utils>=0.1.0',
 ]
 


### PR DESCRIPTION
- FIX Removes calls to PluginManager
  consider_setuptools_entrypoints() removed in PyTest 2.8.0.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
